### PR TITLE
OpenEphyra bugfix

### DIFF
--- a/qa/common/.gitignore
+++ b/qa/common/.gitignore
@@ -2,6 +2,7 @@ question-answer/wiki_indri_index/**
 question-answer/bin/**
 question-answer-*/wiki_indri_index/**
 question-answer-*/bin/**
+question-answer-*/
 wiki_indri_index.tar.gz
 
 !libindri_jni.so

--- a/qa/common/question-answer/src/info/ephyra/search/Search.java
+++ b/qa/common/question-answer/src/info/ephyra/search/Search.java
@@ -138,6 +138,7 @@ public class Search {
 	public static Result[] doSearch(Query[] queries) {
 		results = new ArrayList<Result>();
 		pending = 0;
+		System.out.println("queries.length == " + queries.length);
 		
 		// send only the first query to the KnowledgeAnnotators
 		if (queries.length > 0) queryKAs(queries[0]);
@@ -183,8 +184,15 @@ public class Search {
 	 */
 	public static void addResults(Result[] results) {
 		synchronized (Search.results) {
-			for (Result result : results) Search.results.add(result);
-
+			// Error handling for case when searcher finds no results
+			if (results == null) {
+				System.out.println("Search returned no results " +
+					"for this query");
+			} else {
+				for (Result result : results) {
+					Search.results.add(result);
+				}
+			}
 			pending--;
 			Search.results.notify();  // signal that the query is completed
 		}

--- a/qa/common/question-answer/src/info/ephyra/search/searchers/IndriKM.java
+++ b/qa/common/question-answer/src/info/ephyra/search/searchers/IndriKM.java
@@ -260,7 +260,7 @@ public class IndriKM extends KnowledgeMiner {
 			MsgPrinter.printSearchError(e);  // print search error message
 			
 			MsgPrinter.printErrorMsg("\nSearch failed.");
-			System.exit(1);
+			//System.exit(1);
 			
 			return null;
 		}

--- a/qa/common/question-answer/src/info/ephyra/search/searchers/Searcher.java
+++ b/qa/common/question-answer/src/info/ephyra/search/searchers/Searcher.java
@@ -39,9 +39,9 @@ public abstract class Searcher extends Thread {
 		if (query != null) {
 			// perform search
 			Result[] results = doSearch();
-			
 			// pass results to class Search
 			Search.addResults(results);
+
 		}
 	}
 }

--- a/qa/sirius/QAServiceHandler.java
+++ b/qa/sirius/QAServiceHandler.java
@@ -22,6 +22,7 @@ public class QAServiceHandler implements QAService.Iface {
    * the end-to-end OpenEphyra framework.
    */
   private OpenEphyra oe;
+  private String defaultAnswer;
 
   /** Constructs the handler and initializes its OpenEphyra
    * object.
@@ -33,6 +34,7 @@ public class QAServiceHandler implements QAService.Iface {
     MsgPrinter.enableErrorMsgs(true);
 
     oe = new OpenEphyra(dir);
+    defaultAnswer = "Sorry. I'm not at liberty to disclose this information.";
   }
 
   /** Forwards the client's question to the OpenEphyra object's askFactoid
@@ -43,7 +45,10 @@ public class QAServiceHandler implements QAService.Iface {
     MsgPrinter.printStatusMsg("askFactoidThrift(): Arg = " + question);
     
     Result result = oe.askFactoid(question);
-    String answer = result.getAnswer();
+    String answer = defaultAnswer;
+    if (result != null) {
+      answer = result.getAnswer();
+    }
 
     return answer;
   }
@@ -59,9 +64,13 @@ public class QAServiceHandler implements QAService.Iface {
 
     Result[] results = oe.askList(question, relThresh);
     List<String> answersList = new ArrayList<String>();
-    // add all answers to answersList
-    for (Result r : results) {
-      answersList.add(r.getAnswer());
+    if (results.length > 0) {
+      // add all answers to answersList
+      for (Result r : results) {
+        answersList.add(r.getAnswer());
+      }
+    } else {
+      answersList.add(defaultAnswer);
     }
     return answersList;
   }

--- a/qa/template/QAServiceHandler.java
+++ b/qa/template/QAServiceHandler.java
@@ -22,6 +22,7 @@ public class QAServiceHandler implements QAService.Iface {
    * the end-to-end OpenEphyra framework.
    */
   private OpenEphyra oe;
+  private String defaultAnswer;
 
   /** Constructs the handler and initializes its OpenEphyra
    * object.
@@ -34,6 +35,7 @@ public class QAServiceHandler implements QAService.Iface {
     MsgPrinter.enableErrorMsgs(true);
 
     oe = new OpenEphyra(dir);
+    defaultAnswer = "Sorry. I'm not at liberty to disclose this information.";
   }
 
   /** Forwards the client's question to the OpenEphyra object's askFactoid
@@ -43,9 +45,13 @@ public class QAServiceHandler implements QAService.Iface {
   public String askFactoidThrift(String question)
   {
     MsgPrinter.printStatusMsg("askFactoidThrift(): Arg = " + question);
-    
+   
+    // Returns null if there are no results. 
     Result result = oe.askFactoid(question);
-    String answer = result.getAnswer();
+    String answer = defaultAnswer;
+    if (result != null) {
+      answer = result.getAnswer();
+    }
 
     return answer;
   }
@@ -60,12 +66,16 @@ public class QAServiceHandler implements QAService.Iface {
     
     MsgPrinter.printStatusMsg("askListThrift(): Arg = " + question);
 
+    // Returns an empty array if there are no results.
     Result[] results = oe.askList(question, relThresh);
     List<String> answersList = new ArrayList<String>();
-    // add all answers to answersList
-    for (Result r : results)
-    {
-      answersList.add(r.getAnswer());
+    if (results.length > 0) {
+      // add all answers to answersList
+      for (Result r : results) {
+        answersList.add(r.getAnswer());
+      }
+    } else {
+      answersList.add(defaultAnswer);
     }
     return answersList;
   }


### PR DESCRIPTION
This bugfix prevents OpenEphyra from crashing when any search thread fails to return results, and fixes the NullPointerException that occurs when all search threads fail to return results. A default answer is also introduced.